### PR TITLE
refactor: use crypto.getRandomValues for unbiased reviewer selection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ biome.json                  # Linting/formatting configuration
   - Handles multiple group membership strategies ("merge" vs "first")
   - Implements special selector patterns (`"*"`, `"!groupname"`)
   - Returns detailed selection results with applied rules and process steps
+  - Randomness: `pickRandom` uses `crypto.getRandomValues` with rejection sampling for unbiased selection; `pickRandomDeterministic` provides a seeded variant for deterministic testing
 
 ### Service Layer
 

--- a/src/core/reviewer-selector.ts
+++ b/src/core/reviewer-selector.ts
@@ -406,17 +406,27 @@ export class ReviewerSelector {
   }
 
   /**
-   * Pick random items from a list (using Math.random for production)
+   * Pick random items from a list using crypto.getRandomValues for uniform distribution
    */
   pickRandom(items: string[], n: number, ignore: string[]): string[] {
     const picks: string[] = [];
-    const candidates = items.filter((item) => !ignore.includes(item));
+    const candidates = [
+      ...new Set(items.filter((item) => !ignore.includes(item))),
+    ];
 
+    const randomBytes = new Uint32Array(1);
     while (picks.length < n && candidates.length > 0) {
-      const random = Math.floor(Math.random() * candidates.length);
-      const pick = candidates.splice(random, 1)[0];
+      // Rejection sampling to eliminate modulo bias
+      const limit =
+        Math.floor(0x100000000 / candidates.length) * candidates.length;
+      let value: number;
+      do {
+        crypto.getRandomValues(randomBytes);
+        value = randomBytes[0];
+      } while (value >= limit);
 
-      if (!picks.includes(pick)) picks.push(pick);
+      const pick = candidates.splice(value % candidates.length, 1)[0];
+      picks.push(pick);
     }
 
     return picks;
@@ -432,7 +442,9 @@ export class ReviewerSelector {
     seed = 0,
   ): string[] {
     const picks: string[] = [];
-    const candidates = items.filter((item) => !ignore.includes(item));
+    const candidates = [
+      ...new Set(items.filter((item) => !ignore.includes(item))),
+    ];
 
     // Simple seeded random number generator
     let currentSeed = seed;
@@ -444,8 +456,7 @@ export class ReviewerSelector {
     while (picks.length < n && candidates.length > 0) {
       const random = Math.floor(seededRandom() * candidates.length);
       const pick = candidates.splice(random, 1)[0];
-
-      if (!picks.includes(pick)) picks.push(pick);
+      picks.push(pick);
     }
 
     return picks;


### PR DESCRIPTION

<!-- claude:start -->
## Summary

- `Math.random()` を `crypto.getRandomValues()` + rejection sampling に置き換え、レビュアー抽選の均一性を改善
- 複数グループに所属するユーザーの重複候補を `Set` で排除し、同一ユーザーが2回選出されるバグを防止
- `pickRandomDeterministic`（テスト用）からも冗長な重複チェックを削除
<!-- claude:end -->

<!-- claude:start -->
## Test plan

- [x] 既存テスト全75件パス
- [ ] 4人チームで繰り返し実行し、選出分布の均一性を確認
- [ ] 複数グループに所属するユーザーが重複選出されないことを確認
<!-- claude:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)